### PR TITLE
Improve HTML cleanup

### DIFF
--- a/bot/mail_manager.py
+++ b/bot/mail_manager.py
@@ -65,34 +65,20 @@ def remove_replied_message(text):
 
 def remove_blank_space(text):
     """
-    Очищает текст, убирая лишние пробелы и перевод строки внутри абзацев,
-    оставляя не более одной пустой строки подряд между абзацами.
+    Очищает текст, убирая лишние пробелы в начале и конце строк,
+    оставляя не более одной пустой строки подряд.
     """
     lines = [line.strip() for line in text.split('\n')]
 
-    paragraphs = []
-    current_lines = []
-    for line in lines:
-        if line == '':
-            if current_lines:
-                paragraphs.append(' '.join(current_lines))
-                current_lines = []
-            paragraphs.append('')
-        else:
-            current_lines.append(line)
-
-    if current_lines:
-        paragraphs.append(' '.join(current_lines))
-
     cleaned_lines = []
     previous_empty = False
-    for p in paragraphs:
-        if p == '':
+    for line in lines:
+        if line == '':
             if not previous_empty:
                 cleaned_lines.append('')
                 previous_empty = True
         else:
-            cleaned_lines.append(p)
+            cleaned_lines.append(line)
             previous_empty = False
 
     return '\n'.join(cleaned_lines).strip()

--- a/bot/mail_manager.py
+++ b/bot/mail_manager.py
@@ -65,21 +65,35 @@ def remove_replied_message(text):
 
 def remove_blank_space(text):
     """
-    Очищает текст, оставляя не более одной пустой строки подряд и убирая
-    лишние пробелы по краям строк.
+    Очищает текст, убирая лишние пробелы и перевод строки внутри абзацев,
+    оставляя не более одной пустой строки подряд между абзацами.
     """
     lines = [line.strip() for line in text.split('\n')]
-    cleaned_lines = []
-    previous_empty = False
 
+    paragraphs = []
+    current_lines = []
     for line in lines:
         if line == '':
+            if current_lines:
+                paragraphs.append(' '.join(current_lines))
+                current_lines = []
+            paragraphs.append('')
+        else:
+            current_lines.append(line)
+
+    if current_lines:
+        paragraphs.append(' '.join(current_lines))
+
+    cleaned_lines = []
+    previous_empty = False
+    for p in paragraphs:
+        if p == '':
             if not previous_empty:
                 cleaned_lines.append('')
                 previous_empty = True
         else:
+            cleaned_lines.append(p)
             previous_empty = False
-            cleaned_lines.append(line)
 
     return '\n'.join(cleaned_lines).strip()
 

--- a/bot/mail_manager.py
+++ b/bot/mail_manager.py
@@ -65,23 +65,24 @@ def remove_replied_message(text):
 
 def remove_blank_space(text):
     """
-    Очищает текст, убирая лишние пробелы в начале и конце строк,
-    оставляя не более одной пустой строки подряд.
+    Нормализует абзацы: строки внутри абзаца объединяются через пробел,
+    а между абзацами остаётся только один пустой ряд.
     """
     lines = [line.strip() for line in text.split('\n')]
 
-    cleaned_lines = []
-    previous_empty = False
+    paragraphs = []
+    current = []
     for line in lines:
-        if line == '':
-            if not previous_empty:
-                cleaned_lines.append('')
-                previous_empty = True
+        if line:
+            current.append(line)
         else:
-            cleaned_lines.append(line)
-            previous_empty = False
+            if current:
+                paragraphs.append(' '.join(current))
+                current = []
+    if current:
+        paragraphs.append(' '.join(current))
 
-    return '\n'.join(cleaned_lines).strip()
+    return '\n\n'.join(paragraphs).strip()
 
 
 def clean_html(html_content):

--- a/bot/mail_manager.py
+++ b/bot/mail_manager.py
@@ -65,22 +65,23 @@ def remove_replied_message(text):
 
 def remove_blank_space(text):
     """
-    Очищает текст, оставляя не более одной пустой строки подряд.
+    Очищает текст, оставляя не более одной пустой строки подряд и убирая
+    лишние пробелы по краям строк.
     """
-    lines = text.split('\n')
+    lines = [line.strip() for line in text.split('\n')]
     cleaned_lines = []
-    empty_count = 0
+    previous_empty = False
 
     for line in lines:
-        if line.strip() == '':
-            empty_count += 1
-            if empty_count <= 1:
-                cleaned_lines.append(line)
+        if line == '':
+            if not previous_empty:
+                cleaned_lines.append('')
+                previous_empty = True
         else:
-            empty_count = 0
+            previous_empty = False
             cleaned_lines.append(line)
 
-    return '\n'.join(cleaned_lines)
+    return '\n'.join(cleaned_lines).strip()
 
 
 def clean_html(html_content):
@@ -92,7 +93,7 @@ def clean_html(html_content):
     links = extract_links(soup)
 
     # Удаляем все html теги, кроме текста + сообщение на которое ответили + лишний пустые строки
-    cleaned_text = soup.get_text(separator='\n')
+    cleaned_text = soup.get_text(separator='\n', strip=True)
     cleaned_text = remove_replied_message(cleaned_text)
     cleaned_text = remove_blank_space(cleaned_text)
 
@@ -163,7 +164,9 @@ def extract_multipart_content(msg):
         if content_type == "text/html" and not content_disposition:
             html_body = decode_html_part(part)
         elif "attachment" in content_disposition:
-            attachments.append(decode_attachment(part))
+            attachment = decode_attachment(part)
+            if attachment:
+                attachments.append(attachment)
         elif content_type.startswith("image/") and not content_disposition:
             attachments.append(decode_inline_image(part))
 

--- a/bot/telegram_sender.py
+++ b/bot/telegram_sender.py
@@ -29,6 +29,8 @@ async def send_to_telegram(subject, from_, body, attachments=None):
 
     if attachments:
         for attachment in attachments:
+            if not attachment:
+                continue
             attachment.seek(0)
             if attachment.name.lower().endswith((".jpg", ".jpeg", ".png")):
                 await bot.send_photo(chat_id=TELEGRAM_CHANNEL, photo=attachment)


### PR DESCRIPTION
## Summary
- trim leading/trailing spaces while cleaning email text
- only allow one empty line in sequence
- strip text content when converting HTML to text

## Testing
- `python -m py_compile bot/*.py`
- `python bot/main.py` *(fails: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68407d77f2a0832b9da23d9659e851ad